### PR TITLE
Redis: Changed MaxValue for port to 65535

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
+++ b/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
@@ -17,7 +17,7 @@
       </protected_mode>
       <port type="IntegerField">
         <MinimumValue>1</MinimumValue>
-        <MaximumValue>65536</MaximumValue>
+        <MaximumValue>65535</MaximumValue>
         <Required>N</Required>
         <default>6379</default>
         <ValidationMessage>This must be a valid port number.</ValidationMessage>


### PR DESCRIPTION
Changed MaxValue for the port from 6553**6** to 6553**5**.

Not sure if *PortField* would be better suited here, as both *IntegerField* and *PortField* are used in other places. It's just that the current max of 65536 is out of the valid port range...

While highly unlikely anyone would try this, I just did and it indeed let me set the port to 65536 .