### PR TITLE
Redis: Changed field type of port to PortField

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
+++ b/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
@@ -15,9 +15,7 @@
         <default>1</default>
         <Required>Y</Required>
       </protected_mode>
-      <port type="IntegerField">
-        <MinimumValue>1</MinimumValue>
-        <MaximumValue>65536</MaximumValue>
+      <port type="PortField">
         <Required>N</Required>
         <default>6379</default>
         <ValidationMessage>This must be a valid port number.</ValidationMessage>


### PR DESCRIPTION
Removed the Min and MaxValue, which was set to 65536 instead of 65535 as the upper bound.
Changed the field type from IntegerField to PortField as this handles validation internally.